### PR TITLE
Fix parsing of capture values with colons

### DIFF
--- a/src/hurl-parser.ts
+++ b/src/hurl-parser.ts
@@ -122,14 +122,19 @@ export function parseHurlOutput(
 		} else if (line.startsWith("* Timings:")) {
 			isTimings = true;
 			isCaptures = false;
-		} else if (isTimings && line.trim() !== "") {
-			// Remove the '* ' prefix if it exists
-			const cleanedLine = line.startsWith("* ") ? line.slice(2) : line;
-			const [key, value] = cleanedLine.split(":").map((s) => s.trim());
-			if (currentEntry && key && value) {
-				if (currentEntry.timings) {
-					currentEntry.timings[key] = value;
-				}
+                } else if (isTimings && line.trim() !== "") {
+                        // Remove the '* ' prefix if it exists
+                        const cleanedLine = line.startsWith("* ") ? line.slice(2) : line;
+                        // Use the first ":" so values containing ":" remain intact
+                        const separatorIndex = cleanedLine.indexOf(":");
+                        if (separatorIndex !== -1) {
+                                const key = cleanedLine.slice(0, separatorIndex).trim();
+                                const value = cleanedLine.slice(separatorIndex + 1).trim();
+                                if (currentEntry && key && value) {
+                                        if (currentEntry.timings) {
+                                                currentEntry.timings[key] = value;
+                                        }
+                                }
 				// Check if this is the total timing, which marks the end of timing section
 				if (key === "total") {
 					isTimings = false;
@@ -144,13 +149,18 @@ export function parseHurlOutput(
 			if (currentEntry && !currentEntry.captures) {
 				currentEntry.captures = {};
 			}
-		} else if (isCaptures && line.trim() !== "") {
-			// Remove the '* ' prefix if it exists
-			const cleanedLine = line.startsWith("* ") ? line.slice(2) : line;
-			const [key, value] = cleanedLine.split(":").map((s) => s.trim());
-			if (currentEntry?.captures && key && value) {
-				currentEntry.captures[key] = value;
-			}
+                } else if (isCaptures && line.trim() !== "") {
+                        // Remove the '* ' prefix if it exists
+                        const cleanedLine = line.startsWith("* ") ? line.slice(2) : line;
+                        // Use the first ":" so values containing ":" remain intact
+                        const separatorIndex = cleanedLine.indexOf(":");
+                        if (separatorIndex !== -1) {
+                                const key = cleanedLine.slice(0, separatorIndex).trim();
+                                const value = cleanedLine.slice(separatorIndex + 1).trim();
+                                if (currentEntry?.captures && key && value) {
+                                        currentEntry.captures[key] = value;
+                                }
+                        }
 		} else if (isCaptures && line.trim() === "") {
 			isCaptures = false;
 		}


### PR DESCRIPTION
## Summary
- handle colon in captured values

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'reactive-vscode')*
- `pnpm test` *(fails to install dependencies)*
- `npx biome lint .` *(fails to download dependencies)*